### PR TITLE
Fix time parsing error #21

### DIFF
--- a/internal/pkg/modem/sms.go
+++ b/internal/pkg/modem/sms.go
@@ -45,7 +45,7 @@ func (m *Modem) RetrieveSMS(objectPath dbus.ObjectPath) (*SMS, error) {
 		return nil, err
 	}
 	if t := variant.Value().(string); t != "" {
-		sms.Timestamp, err = time.Parse("2006-01-02T15:04:05Z07", t)
+		sms.Timestamp, err = time.Parse(time.RFC3339, t)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Replace "2006-01-02T15:04:05Z07" with time.RFC3339 to accommodate time zone timestamps with ":00" and more.

Fix #21 